### PR TITLE
fix(logger): pass colors=true to debug module

### DIFF
--- a/src/lighthouse.js
+++ b/src/lighthouse.js
@@ -16,6 +16,8 @@ const getBrowserPath = async () => {
 const runLighthouse = async (browserPath, url) => {
   let chrome;
   try {
+    // prevent logger from prefixing a date when running in tty
+    require('debug').inspectOpts.colors = true;
     const logLevel = 'info';
     log.setLevel(logLevel);
     chrome = await chromeLauncher.launch({


### PR DESCRIPTION
this prevents the debug module from prefixing a date string to log messages in tty

See https://app.netlify.com/sites/elastic-easley-4ab11f/deploys/5eef41bbc8d60e00074ed78f