### PR TITLE
Fix: add chrome --disable-dev-shm-usage flag

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ const getError = (id, expected, results) => {
   return `Expected category ${chalk.magenta(
     category.title,
   )} to be greater or equal to ${chalk.green(expected)} but got ${chalk.red(
-    category.score,
+    category.score !== null ? category.score : 'unknown',
   )}`;
 };
 

--- a/src/lighthouse.js
+++ b/src/lighthouse.js
@@ -22,7 +22,12 @@ const runLighthouse = async (browserPath, url) => {
     log.setLevel(logLevel);
     chrome = await chromeLauncher.launch({
       chromePath: browserPath,
-      chromeFlags: ['--headless', '--no-sandbox', '--disable-gpu'],
+      chromeFlags: [
+        '--headless',
+        '--no-sandbox',
+        '--disable-gpu',
+        '--disable-dev-shm-usage',
+      ],
       logLevel,
     });
     const results = await lighthouse(url, {


### PR DESCRIPTION
Fixes https://github.com/netlify-labs/netlify-plugin-lighthouse/issues/37

See https://github.com/GoogleChrome/chrome-launcher/blob/master/docs/chrome-flags-for-tools.md and https://github.com/GoogleChrome/puppeteer/issues/1834

This fixes the issue, but it looks like the `performance` category returns `null` due to the videos in the site.
Tried using `--autoplay-policy=user-gesture-required # Don't render video`  but didn't work.
Seems like a Lighthouse issue.