### PR TITLE
feat: add input.audit_path

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -3,6 +3,9 @@ inputs:
   - name: audit_url
     required: false
     description: Url of the site to audit, defaults to scanning the current built version of the site
+  - name: audit_path
+    required: false
+    description: Path to audit starts with `/`, defaults to root(= /index.html) and be ignored if audit_url is specified
   - name: thresholds
     required: false
     description: Key value mapping of thresholds that will fail the build when not passed


### PR DESCRIPTION
Currently this plugin seems to allow us to specify audit URL by...

- Specify exact URL w/ `input.audit_url`
- or Published site default root(w/o `input.audit_url`)

If our site dose not have root `index.html`, even if we have `/foo/bar.html` instead, it goes fail.

This PR solve this situation by adding `audit_path` append to site default root path.