### PR TITLE
fix(lighthouse): hide logs timestamp when running in tty

### DIFF
--- a/src/lighthouse.js
+++ b/src/lighthouse.js
@@ -1,3 +1,6 @@
+// prevent logger from prefixing a date when running in tty
+process.env.DEBUG_COLORS = 'true';
+
 const puppeteer = require('puppeteer');
 const lighthouse = require('lighthouse');
 const log = require('lighthouse-logger');
@@ -16,8 +19,6 @@ const getBrowserPath = async () => {
 const runLighthouse = async (browserPath, url) => {
   let chrome;
   try {
-    // prevent logger from prefixing a date when running in tty
-    require('debug').inspectOpts.colors = true;
     const logLevel = 'info';
     log.setLevel(logLevel);
     chrome = await chromeLauncher.launch({


### PR DESCRIPTION
See before:
https://app.netlify.com/sites/plugin-lighthouse/deploys/5f0c23c7c9f52900075bf9ca

```
12:06:16 PM: Mon, 13 Jul 2020 09:06:16 GMT ChromeLauncher Waiting for browser.
12:06:16 PM: Mon, 13 Jul 2020 09:06:16 GMT ChromeLauncher Waiting for browser...
12:06:16 PM: Mon, 13 Jul 2020 09:06:16 GMT ChromeLauncher Waiting for browser.....
12:06:17 PM: Mon, 13 Jul 2020 09:06:17 GMT ChromeLauncher Waiting for browser.......
12:06:17 PM: Mon, 13 Jul 2020 09:06:17 GMT ChromeLauncher Waiting for browser.......✓
12:06:17 PM: Mon, 13 Jul 2020 09:06:17 GMT config:warn IFrameElements gatherer requested, however no audit requires it.
12:06:17 PM: Mon, 13 Jul 2020 09:06:17 GMT config:warn InspectorIssues gatherer requested, however no audit requires it.
12:06:17 PM: Mon, 13 Jul 2020 09:06:17 GMT status Connecting to browser
12:06:17 PM: Mon, 13 Jul 2020 09:06:17 GMT status Resetting state with about:blank
12:06:17 PM: Mon, 13 Jul 2020 09:06:17 GMT status Benchmarking machine
12:06:17 PM: Mon, 13 Jul 2020 09:06:17 GMT status Initializing…
```

And after:
https://app.netlify.com/sites/plugin-lighthouse/deploys/5f0c4a4177fc940007d8a269

```
2:49:52 PM:   ChromeLauncher Waiting for browser. +0ms
2:49:52 PM:   ChromeLauncher Waiting for browser... +1ms
2:49:53 PM:   ChromeLauncher Waiting for browser..... +505ms
2:49:53 PM:   ChromeLauncher Waiting for browser.....✓ +3ms
2:49:53 PM:   config:warn IFrameElements gatherer requested, however no audit requires it. +223ms
2:49:53 PM:   config:warn InspectorIssues gatherer requested, however no audit requires it. +0ms
2:49:53 PM:   status Connecting to browser +21ms
2:49:53 PM:   status Resetting state with about:blank +15ms
2:49:53 PM:   status Benchmarking machine +54ms
2:49:53 PM:   status Initializing… +507ms
```

Lighthouse uses `debug` as a dependency which appends a timestamp when in tty:
https://github.com/visionmedia/debug/blob/80ef62a3af4df95250d77d64edfc3d0e1667e7e8/src/node.js#L174
https://github.com/visionmedia/debug/blob/80ef62a3af4df95250d77d64edfc3d0e1667e7e8/src/node.js#L151

With older versions (like the one lighthouse uses) the only way to change it is via `colors` option (with newer versions there is a simpler `hideDate` option).

We previously used `require('debug').inspectOpts.colors = true` to set the option, but that only works for the resolved version of `debug` and not all versions in the dependency tree.

A better fix is to use an environment variable to set the option for all `debug` versions. See https://github.com/visionmedia/debug/blob/80ef62a3af4df95250d77d64edfc3d0e1667e7e8/src/node.js#L120
