### PR TITLE
fix: use onPostBuild instead of onSuccess

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -207,7 +207,7 @@ const processResults = ({ summaries, errors }) => {
 };
 
 module.exports = {
-  onSuccess: async ({ constants, utils, inputs } = {}) => {
+  onPostBuild: async ({ constants, utils, inputs } = {}) => {
     const { failBuild, show } = getUtils({ utils });
 
     try {


### PR DESCRIPTION
Since we're running the Lighthouse audit after the site was built, it makes sense to have it run on `onPostBuild`.
Related to https://github.com/netlify/plugins/issues/134