### PR TITLE
chore!: drop support for Node 10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [12.x, 15.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "puppeteer": "^8.0.0"
   },
   "engines": {
-    "node": ">=v10.22.1"
+    "node": ">=12.13.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This drops support for Node 10.
This will allow merging https://github.com/netlify-labs/netlify-plugin-lighthouse/pull/134
This will require using `compatibility: { nodeVersion }` in `netlify/plugins.json`.