### PR TITLE
chore: run CI on latest Node.js

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 15.x]
+        node-version: [12.x, '*']
 
     steps:
       - uses: actions/checkout@v2
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          check-latest: true
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ command = "echo 'no op'"
 publish = "example"
 
 [build.environment]
-NODE_VERSION = "15"
+NODE_VERSION = "node"
 
 [[plugins]]
 package = "./src/index.js"


### PR DESCRIPTION
Part of https://github.com/netlify/team-dev/issues/19

This runs the CI on the `latest` Node.js version.