### PR TITLE
Add settings info to the message shown as each run starts

### DIFF
--- a/src/lib/run-event/helpers.js
+++ b/src/lib/run-event/helpers.js
@@ -1,0 +1,21 @@
+export const formatStartMessage = ({ count, path, formFactor, locale }) => {
+  const message = ['Running Lighthouse on', path];
+
+  // Build a list of settings used for this run.
+  const settings = [];
+  if (locale) {
+    settings.push(`the “${locale}” locale`);
+  }
+  if (formFactor === 'desktop') {
+    settings.push('the “desktop” preset');
+  }
+  if (settings.length) {
+    message.push(`using ${settings.join(' and ')}`);
+  }
+
+  if (count?.total > 1) {
+    message.push(`(${count.i}/${count.total})`);
+  }
+
+  return message.join(' ');
+};

--- a/src/lib/run-event/helpers.test.js
+++ b/src/lib/run-event/helpers.test.js
@@ -1,0 +1,51 @@
+import { formatStartMessage } from './helpers.js';
+
+describe('formatStartMessage', () => {
+  it('should format a message using only the path', () => {
+    const result = formatStartMessage({ path: 'https://example.com/path' });
+    expect(result).toEqual('Running Lighthouse on https://example.com/path');
+  });
+
+  it('should format a message using only the path and count', () => {
+    const result = formatStartMessage({
+      count: { i: 1, total: 2 },
+      path: 'https://example.com/path',
+    });
+    expect(result).toEqual(
+      'Running Lighthouse on https://example.com/path (1/2)',
+    );
+  });
+
+  it('should format a message using a single feature', () => {
+    const result = formatStartMessage({
+      path: 'https://example.com/path',
+      formFactor: 'desktop',
+    });
+    expect(result).toEqual(
+      'Running Lighthouse on https://example.com/path using the “desktop” preset',
+    );
+  });
+
+  it('should format a message using multiple features', () => {
+    const result = formatStartMessage({
+      path: 'https://example.com/path',
+      formFactor: 'desktop',
+      locale: 'de',
+    });
+    expect(result).toEqual(
+      'Running Lighthouse on https://example.com/path using the “de” locale and the “desktop” preset',
+    );
+  });
+
+  it('should format a message using all available inputs', () => {
+    const result = formatStartMessage({
+      count: { i: 1, total: 2 },
+      path: 'https://example.com/path',
+      formFactor: 'desktop',
+      locale: 'es',
+    });
+    expect(result).toEqual(
+      'Running Lighthouse on https://example.com/path using the “es” locale and the “desktop” preset (1/2)',
+    );
+  });
+});

--- a/src/lib/run-event/index.js
+++ b/src/lib/run-event/index.js
@@ -6,6 +6,8 @@ import runAuditWithUrl from '../../lib/run-audit-with-url/index.js';
 import runAuditWithServer from '../../lib/run-audit-with-server/index.js';
 import getConfiguration from '../get-configuration/index.js';
 
+import { formatStartMessage } from './helpers.js';
+
 const runEvent = async ({
   event,
   constants,
@@ -57,12 +59,14 @@ const runEvent = async ({
       const { serveDir, path, url, thresholds, output_path } = auditConfig;
       const fullPath = [serveDir, path].join('/');
 
-      let countMessage = '';
-      if (auditConfigs.length > 1) {
-        countMessage = ` (${i}/${auditConfigs.length})`;
-      }
+      const startMessage = formatStartMessage({
+        count: { i, total: auditConfigs.length },
+        path: fullPath,
+        formFactor: settings?.settings.formFactor,
+        locale: settings?.settings.locale,
+      });
 
-      console.log(`Running Lighthouse on ${fullPath}${countMessage}`);
+      console.log(startMessage);
 
       const runner = isOnSuccess ? runAuditWithUrl : runAuditWithServer;
       const { errors, summary, shortSummary, details, report, runtimeError } =


### PR DESCRIPTION
Adds a function to embellish the "Running Lighthouse on example/" message using supplied settings. This helps verify settings have been picked up correctly without needing to wait and review the final report output. I wonder if it's too wordy – maybe we look again if we expose more settings in future.

Screenshots taken locally. The changes affect the output of a single console.log so should be identical in build logs

### Examples

Single run, no custom settings
<img width="566" alt="image" src="https://user-images.githubusercontent.com/720908/229833328-db37e613-fdd1-44ee-ba15-71e415dd05cf.png">

Multi-page run, no custom settings
<img width="565" alt="image" src="https://user-images.githubusercontent.com/720908/229832553-f7ddbf79-e783-41fe-93cd-37e98e81cb64.png">

With a single custom setting
<img width="783" alt="image" src="https://user-images.githubusercontent.com/720908/229832841-bc513dff-9b00-491e-b83c-d7bd3c67cfb4.png">

With multiple custom settings
<img width="958" alt="image" src="https://user-images.githubusercontent.com/720908/229832989-1e29ca9d-072f-42bb-9774-239923d560cf.png">

